### PR TITLE
filter processed images using a glob-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Then configure the versions you'd like to generate.
 ```json
 {
   "images": {
+    "match": "**/pictures/*.jpg",
     "versions": {
       "small": {
         "resize": [300, 300]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "coffee-script": "^1.7.1",
     "gm": "^1.18.1",
-    "lodash": "^3.10.0"
+    "lodash": "^3.10.0",
+    "minimatch": "~3.0.0"
   }
 }

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -1,11 +1,13 @@
 gm = require 'gm'
 path = require 'path'
 fs = require 'fs'
+minimatch = require 'minimatch'
 _ = require 'lodash'
 
 module.exports = (env, callback) ->
 
   defaults =
+    pattern: '**/*.{png,jpg}'
     versions:
       thumbnail:
         resize: [100, 100]
@@ -19,7 +21,7 @@ module.exports = (env, callback) ->
   getImages = (contents) ->
     images = env.ContentTree.flatten contents
     images = images.filter (content) ->
-      content.filepath?.relative.match /(png|jpg)$/
+      minimatch content.filepath?.relative, options.pattern, {dot: false}
     return images
 
   formatFileName = (filename, version) ->


### PR DESCRIPTION
this PR uses the same glob-library as `wintersmith` uses to map Content-Plugins to filename Patterns. It allows to restrict the processed images and defaults to the original "all jpg and png" filter.
