### PR TITLE
group generated versions into their own content-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,11 @@ You can use most of the methods specified in the gm docs listed [here](http://ah
 Then use the generated version in your templates.
 
 ```jade
-  img(src=env.helpers.getImageUrl(contents, '/path/to/myimage.png', 'large'))
+h2 original images
+- for image in page.parent.pictures._.files
+  img(src=image.url)
+
+h2 resized images
+- for image in page.parent.pictures._.images_small
+  img(src=image.url)
 ````

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -89,20 +89,21 @@ module.exports = (env, callback) ->
 
     return _.get(contents, treePath).url
 
-  env.registerGenerator 'images', (contents, callback) ->
-    images = getImages(contents)
+  for version of options.versions
+    do (version) ->
+      env.registerGenerator 'images_'+version, (contents, callback) ->
+        images = getImages(contents)
 
-    tree = {}
+        tree = {}
 
-    for image in images
-      parsed = path.parse image.filepath.relative
-      for version of options.versions
-        name = formatFileName(image.filepath.relative, version)
+        for image in images
+          parsed = path.parse image.filepath.relative
+          name = formatFileName(image.filepath.relative, version)
 
-        treePath = parsed.dir.split('/')
-        treePath.push name
-        _.set tree, treePath, new ImagePlugin(image.filepath, version)
+          treePath = parsed.dir.split('/')
+          treePath.push name
+          _.set tree, treePath, new ImagePlugin(image.filepath, version)
 
-    callback null, tree
+        callback null, tree
 
   callback()


### PR DESCRIPTION
This Pull-Request changes the Content-Group of the ContentGenerator, so that each Image-Version is stored under it's own Conent-Group.

This allows accessing the various Versions using wintersmith's Content-Tree methods (see Readme)
